### PR TITLE
Allow callback to capture child_process instance

### DIFF
--- a/lib/launch.js
+++ b/lib/launch.js
@@ -5,14 +5,14 @@ var path = require('path')
 var mkdirp = require('mkdirp')
 var download = require('./download')
 
-function launch(options) {
+function launch(options, callback) {
 
   options = options || {};
 
   options.port = options.port || 8000;
 
   download(options.version, function(err, info) {
-    if (err) return callback(err);
+    if (err && callback) return callback(err);
 
     var opts = {
       env: process.env,
@@ -48,7 +48,9 @@ function launch(options) {
       args.push('--inMemory')
     }
 
-    return cp.spawn('java', args, opts);
+    var result = cp.spawn('java', args, opts);
+    if(callback) callback(null, result);
+    return result;
   })
 }
 


### PR DESCRIPTION
Hi there, I was trying to use this library to start/stop a dynamo-local instance for unit tests. I could not figure out how to get the reference to the child_process in order to shutdown the process after my tests. I see that the child process instance is being returned from the internal callback method, but I don't think that reference ever gets returned anywhere for the caller to use. 

I see where you made the changes in d8a250d3951178bd70981c9b7d81ac5d801f9d5d to remove the callback in a previous version, mentioning "fixed callback issue", but I couldn't see what the original problem was that needed to be resolved. I tried running the unit-tests on your master branch and the process stayed running for me indefinitely. It also looks like there was a lingering reference to callback(err) that had been left in the code, even though the callback variable was no longer present.

After applying my changes, the existing test completes successfully.